### PR TITLE
Minor code edits

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -161,7 +161,7 @@ function BezierPath:_InterpolateT(Lookup: LookUp, T1: number): number
 	local hi = #distances
 
 	repeat --Binary search to find the correct distance value in the look up table and map it to get uniform positioning across the curve
-		local i = math.floor(lo + (hi - lo) / 2)
+		local i = lo + (hi - lo) // 2
 		local value = distances[i + 1]
 		local previousValue = distances[i]
 
@@ -207,7 +207,7 @@ function BezierPath:_CalculateLength(Positions: { Vector3 }): number
 	local Length = 0
 	local Epsilon = 1/DEFAULT_EPSILON --Step amount using an epsilon
 
-	for i = 0,1,Epsilon do --approximate the length cause beziers dont have a length formula :(
+	for i = 0,1,Epsilon do --approximate the length cause beziers don't have a length formula :(
 		local Pos1,Pos2 = self:_CalculateSectionPosition(Positions,i),self:_CalculateSectionPosition(Positions,i+Epsilon)
 		Length += (Pos1 - Pos2).Magnitude
 	end
@@ -228,7 +228,7 @@ function BezierPath:_CreateSectionLookup(Section: Section): LookUp
 		local Position = self:_CalculateSectionPosition(Section.Positions, i / Segments)
 		local deltaPosition = prevPosition - Position
 		local SegmentLength = deltaPosition.Magnitude
-		AccumulatedDistance = AccumulatedDistance + SegmentLength --Update the accumlated distance based on the previous position and the new position
+		AccumulatedDistance = AccumulatedDistance + SegmentLength --Update the accumulated distance based on the previous position and the new position
 		LookUp.Distances[i] = AccumulatedDistance
 		prevPosition = Position
 	end
@@ -254,7 +254,7 @@ function BezierPath:_Setup(StartingPositions: { Vector3 })
 
 	table.insert(newWaypoints,StartingPositions[1] - (StartingPositions[1] - StartingPositions[2]).Unit * self:_ClampDistance(StartingPositions[1],StartingPositions[2]))
 
-	for i = 2,#StartingPositions-1 do --Generate the control points for each sections bezier by using the previous and next position
+	for i = 2,#StartingPositions-1 do --Generate the control points for each section's bezier by using the previous and next position
 		local CurrentPosition = StartingPositions[i]
 		local NextPosition = StartingPositions[i + 1]
 		local PreviousPosition = StartingPositions[i - 1]

--- a/src/init.lua
+++ b/src/init.lua
@@ -101,7 +101,7 @@ function BezierPath:_CalculateDerivative(Positions: { Vector3 }, t: number): Vec
 	return bezder(Positions[1], Positions[2], Positions[3], t)
 end
 
-function BezierPath:_CalculateCFrame(Positions: { Vector3 }, t: number): CFrame --More effiecent than using the derivative
+function BezierPath:_CalculateCFrame(Positions: { Vector3 }, t: number): CFrame --More efficient than using the derivative
 	local pos = bez(Positions[1], Positions[2], Positions[3], t)
 	local lookAt = bez(Positions[1], Positions[2], Positions[3], t + 1/DEFAULT_EPSILON)
 	return CFrame.lookAt(pos, lookAt)

--- a/src/init.lua
+++ b/src/init.lua
@@ -104,7 +104,7 @@ end
 function BezierPath:_CalculateCFrame(Positions: { Vector3 }, t: number): CFrame --More effiecent than using the derivative
 	local pos = bez(Positions[1], Positions[2], Positions[3], t)
 	local lookAt = bez(Positions[1], Positions[2], Positions[3], t + 1/DEFAULT_EPSILON)
-	return CFrame.new(pos, lookAt)
+	return CFrame.lookAt(pos, lookAt)
 end
 
 --function PathBezier:CalculateCFrame(Positions,t)

--- a/src/init.lua
+++ b/src/init.lua
@@ -156,12 +156,12 @@ function BezierPath:_InterpolateT(Lookup: LookUp, T1: number): number
 	local n = #distances - 1 
 	local targetDistance = self.PathLength * T1 --Translate T value to the distance along the path
 
-	--Indexs for binary search
+	--Indexes for binary search
 	local lo = 0
 	local hi = #distances
 
 	repeat --Binary search to find the correct distance value in the look up table and map it to get uniform positioning across the curve
-		local i = lo + (hi - lo) // 2
+		local i = (lo + hi) // 2
 		local value = distances[i + 1]
 		local previousValue = distances[i]
 
@@ -175,7 +175,7 @@ function BezierPath:_InterpolateT(Lookup: LookUp, T1: number): number
 				i / n,
 				(i + 1) / n
 			)  
-		elseif value > targetDistance then --if not found, update the indexs and continue the binary search
+		elseif value > targetDistance then --if not found, update the indexes and continue the binary search
 			hi = i
 		else
 			lo = i + 1


### PR DESCRIPTION
Replaced `CFrame.new(pos, lookAt)` with `CFrame.lookAt(pos, lookAt)` for performance boost and readability. 
Replace `math.floor` with floor division operator for performance boost (around 2x faster than `math.floor`).
Fixed grammatical errors and typos.

You could maybe use `CFrame.lookAlong` here instead of recalculating the position but I'm not sure.